### PR TITLE
chg: changes for compatibility to 0.0.4+

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,11 +6,10 @@
 import https from "https"
 
 import { createStore } from 'vuex'
-import { LokAPI, e as LokAPIExc, t as LokAPIType } from "lokapi"
+import { LokAPIAbstract, e as LokAPIExc, t as LokAPIType } from "lokapi"
 
-
-let coreHttpRequest: LokAPIType.IHttpRequest = {
-  request: (opts: LokAPIType.coreHttpOpts) => {
+class LokAPI extends LokAPIAbstract {
+  request = (opts: LokAPIType.coreHttpOpts) => {
     if (opts.protocol !== 'https') {
       throw new Error(`Protocol ${opts.protocol} unsupported by this implementation`)
     }
@@ -47,8 +46,8 @@ let coreHttpRequest: LokAPIType.IHttpRequest = {
         reject(new LokAPIExc.RequestFailed(err.message))
       });
     })
-
-  },
+  }
+  base64encode = (s: string) => Buffer.from(s).toString('base64')
 }
 
 
@@ -66,10 +65,6 @@ if (!process.env.VUE_APP_LOKAPI_DB) {
 var lokAPI = new LokAPI(
   process.env.VUE_APP_LOKAPI_HOST,
   process.env.VUE_APP_LOKAPI_DB,
-  {
-    httpRequest: coreHttpRequest,
-    base64encode: (s: string) => Buffer.from(s).toString('base64'),
-  }
 )
 
 
@@ -110,7 +105,7 @@ const moduleLokAPI = {
     auth_success(state: any, token: string) {
       state.status = 'success'
       state.token = token
-      state.userData = lokAPI.userData
+      state.userData = lokAPI.odoo.userData
       state.userProfile = lokAPI.odoo.userProfile
       state.apiToken = lokAPI.odoo.apiToken
       console.log(lokAPI.odoo.apiToken)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,7 +9,7 @@ import { createStore } from 'vuex'
 import { LokAPIAbstract, e as LokAPIExc, t as LokAPIType } from "lokapi"
 
 class LokAPI extends LokAPIAbstract {
-  request = (opts: LokAPIType.coreHttpOpts) => {
+  httpRequest = (opts: LokAPIType.coreHttpOpts) => {
     if (opts.protocol !== 'https') {
       throw new Error(`Protocol ${opts.protocol} unsupported by this implementation`)
     }
@@ -47,7 +47,7 @@ class LokAPI extends LokAPIAbstract {
       });
     })
   }
-  base64encode = (s: string) => Buffer.from(s).toString('base64')
+  base64Encode = (s: string) => Buffer.from(s).toString('base64')
 }
 
 
@@ -89,13 +89,18 @@ const moduleLokAPI = {
       try {
         await lokAPI.login(login, password)
       } catch (err) { // {RequestFailed, APIRequestFailed, InvalidCredentials, InvalidJson}
-        console.log('Login failed: ', err.message)
+        console.log('Login failed:', err.message)
         commit('auth_error')
         localStorage.removeItem('token')
         throw err
       }
-      localStorage.setItem('lokapiToken', lokAPI.odoo.apiToken)
-      commit('auth_success', lokAPI.odoo.apiToken)
+      localStorage.setItem('lokapiToken', lokAPI.apiToken)
+      console.log(lokAPI.apiToken)
+      console.log('lokAPI:', lokAPI)
+      let accounts = await lokAPI.backends[0].accounts
+      console.log('amount:', accounts[0].balance)
+      console.log('currency:', accounts[0].symbol)
+      commit('auth_success', lokAPI.apiToken)
     },
   },
   mutations: {
@@ -105,10 +110,9 @@ const moduleLokAPI = {
     auth_success(state: any, token: string) {
       state.status = 'success'
       state.token = token
-      state.userData = lokAPI.odoo.userData
-      state.userProfile = lokAPI.odoo.userProfile
-      state.apiToken = lokAPI.odoo.apiToken
-      console.log(lokAPI.odoo.apiToken)
+      state.userData = lokAPI.userData
+      state.userProfile = lokAPI.userProfile
+      state.apiToken = lokAPI.apiToken
     },
     auth_error(state: any) {
       state.status = 'error'


### PR DESCRIPTION
There are some important changes to remain compatible with 0.0.4+ ... I replaced the mixin strategy with the better abstract method one for the same benefits. Please contact me if anything seems wrong.